### PR TITLE
Phone login added

### DIFF
--- a/.idea/deploymentTargetSelector.xml
+++ b/.idea/deploymentTargetSelector.xml
@@ -4,9 +4,14 @@
     <selectionStates>
       <SelectionState runConfigName="app">
         <option name="selectionMode" value="DROPDOWN" />
-      </SelectionState>
-      <SelectionState runConfigName="AdminPageActivityEspressoTest">
-        <option name="selectionMode" value="DROPDOWN" />
+        <DropdownSelection timestamp="2026-04-02T22:47:50.921381200Z">
+          <Target type="DEFAULT_BOOT">
+            <handle>
+              <DeviceId pluginId="LocalEmulator" identifier="path=C:\Users\HP\.android\avd\Pixel_8.avd" />
+            </handle>
+          </Target>
+        </DropdownSelection>
+        <DialogSelection />
       </SelectionState>
     </selectionStates>
   </component>

--- a/app/src/androidTest/java/com/example/soen345_winter2026/LogInActivityEspressoTest.kt
+++ b/app/src/androidTest/java/com/example/soen345_winter2026/LogInActivityEspressoTest.kt
@@ -6,7 +6,6 @@ import androidx.test.espresso.assertion.ViewAssertions.matches
 import androidx.test.espresso.matcher.ViewMatchers.*
 import androidx.test.ext.junit.rules.ActivityScenarioRule
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import com.example.soen345_winter2026.R
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -19,15 +18,16 @@ class LogInActivityEspressoTest {
 
     @Test
     fun loginScreen_displaysAllUIElements() {
-        onView(withId(R.id.etEmail)).check(matches(isDisplayed()))
+        onView(withId(R.id.etEmailPhone)).check(matches(isDisplayed()))
         onView(withId(R.id.etPassword)).check(matches(isDisplayed()))
         onView(withId(R.id.btnLogin)).check(matches(isDisplayed()))
+        onView(withId(R.id.adminBtnLogin)).check(matches(isDisplayed()))
         onView(withId(R.id.btnSignUp)).check(matches(isDisplayed()))
     }
 
     @Test
     fun loginScreen_emailFieldHasCorrectHint() {
-        onView(withId(R.id.etEmail)).check(matches(withHint("Email")))
+        onView(withId(R.id.etEmailPhone)).check(matches(withHint("Email or phone (if phone, numbers only)")))
     }
 
     @Test
@@ -41,15 +41,27 @@ class LogInActivityEspressoTest {
     }
 
     @Test
+    fun loginScreen_adminLoginButtonHasCorrectText() {
+        onView(withId(R.id.adminBtnLogin)).check(matches(withText("Admin Login")))
+    }
+
+    @Test
     fun loginScreen_signUpLinkHasCorrectText() {
         onView(withId(R.id.btnSignUp)).check(matches(withText("Don't have an account? Sign Up")))
     }
 
     @Test
     fun loginScreen_canTypeInEmailField() {
-        onView(withId(R.id.etEmail))
+        onView(withId(R.id.etEmailPhone))
             .perform(typeText("test@test.com"), closeSoftKeyboard())
-        onView(withId(R.id.etEmail)).check(matches(withText("test@test.com")))
+        onView(withId(R.id.etEmailPhone)).check(matches(withText("test@test.com")))
+    }
+
+    @Test
+    fun loginScreen_canTypePhoneInEmailField() {
+        onView(withId(R.id.etEmailPhone))
+            .perform(typeText("15143334444"), closeSoftKeyboard())
+        onView(withId(R.id.etEmailPhone)).check(matches(withText("15143334444")))
     }
 
     @Test
@@ -71,8 +83,13 @@ class LogInActivityEspressoTest {
     }
 
     @Test
+    fun loginScreen_adminLoginButtonIsClickable() {
+        onView(withId(R.id.adminBtnLogin)).check(matches(isClickable()))
+    }
+
+    @Test
     fun loginScreen_emailFieldIsEnabled() {
-        onView(withId(R.id.etEmail)).check(matches(isEnabled()))
+        onView(withId(R.id.etEmailPhone)).check(matches(isEnabled()))
     }
 
     @Test

--- a/app/src/androidTest/java/com/example/soen345_winter2026/SignUpActivityEspressoTest.kt
+++ b/app/src/androidTest/java/com/example/soen345_winter2026/SignUpActivityEspressoTest.kt
@@ -6,7 +6,6 @@ import androidx.test.espresso.assertion.ViewAssertions.matches
 import androidx.test.espresso.matcher.ViewMatchers.*
 import androidx.test.ext.junit.rules.ActivityScenarioRule
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import com.example.soen345_winter2026.R
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -21,10 +20,12 @@ class SignUpActivityEspressoTest {
     fun signUpScreen_displaysAllUIElements() {
         onView(withId(R.id.etFullName)).check(matches(isDisplayed()))
         onView(withId(R.id.etEmail)).check(matches(isDisplayed()))
+        onView(withId(R.id.etPhone)).check(matches(isDisplayed()))
         onView(withId(R.id.etPassword)).check(matches(isDisplayed()))
         onView(withId(R.id.etConfirmPassword)).check(matches(isDisplayed()))
-        onView(withId(R.id.btnSignUp)).check(matches(isDisplayed()))
-        onView(withId(R.id.tvLogin)).check(matches(isDisplayed()))
+        onView(withId(R.id.swIsAdmin)).perform(scrollTo()).check(matches(isDisplayed()))
+        onView(withId(R.id.btnSignUp)).perform(scrollTo()).check(matches(isDisplayed()))
+        onView(withId(R.id.tvLogin)).perform(scrollTo()).check(matches(isDisplayed()))
     }
 
     @Test
@@ -34,7 +35,12 @@ class SignUpActivityEspressoTest {
 
     @Test
     fun signUpScreen_emailFieldHasCorrectHint() {
-        onView(withId(R.id.etEmail)).check(matches(withHint("Email")))
+        onView(withId(R.id.etEmail)).check(matches(withHint("Email (optional with phone)")))
+    }
+
+    @Test
+    fun signUpScreen_phoneFieldHasCorrectHint() {
+        onView(withId(R.id.etPhone)).check(matches(withHint("Phone, numbers only (optional with email)")))
     }
 
     @Test
@@ -53,6 +59,11 @@ class SignUpActivityEspressoTest {
     }
 
     @Test
+    fun signUpScreen_adminSwitchIsUncheckedByDefault() {
+        onView(withId(R.id.swIsAdmin)).check(matches(isNotChecked()))
+    }
+
+    @Test
     fun signUpScreen_loginLinkHasCorrectText() {
         onView(withId(R.id.tvLogin)).check(matches(withText("Already have an account? Login")))
     }
@@ -63,6 +74,8 @@ class SignUpActivityEspressoTest {
             .perform(typeText("John Doe"), closeSoftKeyboard())
         onView(withId(R.id.etEmail))
             .perform(typeText("john@test.com"), closeSoftKeyboard())
+        onView(withId(R.id.etPhone))
+            .perform(typeText("15143334444"), closeSoftKeyboard())
         onView(withId(R.id.etPassword))
             .perform(typeText("pass123"), closeSoftKeyboard())
         onView(withId(R.id.etConfirmPassword))
@@ -70,6 +83,7 @@ class SignUpActivityEspressoTest {
 
         onView(withId(R.id.etFullName)).check(matches(withText("John Doe")))
         onView(withId(R.id.etEmail)).check(matches(withText("john@test.com")))
+        onView(withId(R.id.etPhone)).check(matches(withText("15143334444")))
     }
 
     @Test
@@ -81,6 +95,7 @@ class SignUpActivityEspressoTest {
     fun signUpScreen_allFieldsAreEnabled() {
         onView(withId(R.id.etFullName)).check(matches(isEnabled()))
         onView(withId(R.id.etEmail)).check(matches(isEnabled()))
+        onView(withId(R.id.etPhone)).check(matches(isEnabled()))
         onView(withId(R.id.etPassword)).check(matches(isEnabled()))
         onView(withId(R.id.etConfirmPassword)).check(matches(isEnabled()))
     }

--- a/app/src/main/java/com/example/soen345_winter2026/LogInActivity.kt
+++ b/app/src/main/java/com/example/soen345_winter2026/LogInActivity.kt
@@ -51,7 +51,7 @@ class LogInActivity : ComponentActivity() {
     }
 
     private fun handleUserLogin() {
-        val email = binding.etEmail.text.toString()
+        val email = binding.etEmailPhone.text.toString()
         val password = binding.etPassword.text.toString()
 
         if (email.isEmpty() || password.isEmpty()) {
@@ -73,7 +73,7 @@ class LogInActivity : ComponentActivity() {
     }
 
     private fun handleAdminLogin() {
-        val email = binding.etEmail.text.toString().trim()
+        val email = binding.etEmailPhone.text.toString().trim()
         val password = binding.etPassword.text.toString()
 
         if (email.isEmpty() || password.isEmpty()) {

--- a/app/src/main/java/com/example/soen345_winter2026/SignUpActivity.kt
+++ b/app/src/main/java/com/example/soen345_winter2026/SignUpActivity.kt
@@ -5,6 +5,7 @@ import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
 import com.example.soen345_winter2026.database.RegistrationDB
 import com.example.soen345_winter2026.databinding.SignUpBinding
+import com.example.soen345_winter2026.utils.Validator
 
 class SignUpActivity : AppCompatActivity() {
 
@@ -24,16 +25,27 @@ class SignUpActivity : AppCompatActivity() {
         binding.btnSignUp.setOnClickListener {
             val fullName = binding.etFullName.text.toString()
             val email = binding.etEmail.text.toString()
+            val phone = binding.etPhone.text.toString()
             val password = binding.etPassword.text.toString()
             val confirmPassword = binding.etConfirmPassword.text.toString()
             val isAdmin = binding.swIsAdmin.isChecked
 
-            if (email.isEmpty() || password.isEmpty() || fullName.isEmpty()) {
-                Toast.makeText(this, "Fields cannot be empty", Toast.LENGTH_SHORT).show()
+            if (fullName.isEmpty()) {
+                Toast.makeText(this, "Full name cannot be empty", Toast.LENGTH_SHORT).show()
+                return@setOnClickListener
+            } else if (email.isEmpty() && phone.isEmpty()) {
+                Toast.makeText(this, "Please provide either email or phone", Toast.LENGTH_SHORT).show()
+                return@setOnClickListener
+            } else if (email.isNotEmpty() && !Validator.isValidEmail(email)) {
+                Toast.makeText(this, "Please enter a valid email address", Toast.LENGTH_SHORT).show()
+                return@setOnClickListener
+            } else if (phone.isNotEmpty() && !Validator.isValidPhoneNumber(phone)) {
+                Toast.makeText(this, "Please enter a valid phone number (digits only)", Toast.LENGTH_SHORT).show()
+                return@setOnClickListener
             } else if (password != confirmPassword) {
                 Toast.makeText(this, "Passwords do not match", Toast.LENGTH_SHORT).show()
             } else {
-                registrationDB.signUp(email, password, fullName, isAdmin) { success, error ->
+                registrationDB.signUp(email, phone, password, fullName, isAdmin) { success, error ->
 
                     if (success) {
                         Toast.makeText(this, "Account Created", Toast.LENGTH_SHORT).show()

--- a/app/src/main/java/com/example/soen345_winter2026/database/RegistrationDB.kt
+++ b/app/src/main/java/com/example/soen345_winter2026/database/RegistrationDB.kt
@@ -14,30 +14,11 @@ class RegistrationDB(
         return "$phone@phone.com"
     }
 
-    // finds either the actual email linked to the acc
-    // or the phone-turned-email fake email linked
-    private fun lookupEmailByPhone(phone: String, callback: (String?, String?) -> Unit) {
-        db.collection("users")
-            .whereEqualTo("phone", phone)
-            .get()
-            .addOnSuccessListener { documents ->
-                if (!documents.isEmpty) {
-                    val email = documents.documents[0].getString("email")
-                    callback(email, null)
-                } else {
-                    callback(null, "No account found for this phone number")
-                }
-            }
-            .addOnFailureListener { e ->
-                callback(null, e.message)
-            }
-    }
-
-    private fun resolveAuthEmail(input: String, callback: (String?, String?) -> Unit) {
-        when {
-            Validator.isValidEmail(input) -> callback(input, null)
-            Validator.isValidPhoneNumber(input) -> lookupEmailByPhone(input, callback)
-            else -> callback(null, "Invalid email or phone number")
+    private fun resolveAuthEmail(input: String): Pair<String?, String?> {
+        return when {
+            Validator.isValidEmail(input) -> Pair(input, null)
+            Validator.isValidPhoneNumber(input) -> Pair(phoneToEmail(input), null)
+            else -> Pair(null, "Invalid email or phone number")
         }
     }
 
@@ -96,22 +77,20 @@ class RegistrationDB(
         callback: (Boolean, String?) -> Unit
     ) {
 
-        resolveAuthEmail(input) { email, error ->
-            if (email == null) {
-                callback(false, error)
-                return@resolveAuthEmail
-            }
-
-
-            auth.signInWithEmailAndPassword(email, password)
-                .addOnCompleteListener { task ->
-                    if (task.isSuccessful) {
-                        callback(true, null)
-                    } else {
-                        callback(false, task.exception?.message)
-                    }
-                }
+        val (email, error) = resolveAuthEmail(input)
+        if (email == null) {
+            callback(false, error)
+            return
         }
+
+        auth.signInWithEmailAndPassword(email, password)
+            .addOnCompleteListener { task ->
+                if (task.isSuccessful) {
+                    callback(true, null)
+                } else {
+                    callback(false, task.exception?.message)
+                }
+            }
     }
 
     fun adminLogIn(
@@ -119,36 +98,33 @@ class RegistrationDB(
         password: String,
         callback: (Boolean, Boolean, String?) -> Unit) {
 
-        resolveAuthEmail(input) { email, error ->
-            if (email == null) {
-                callback(false, false, error)
-                return@resolveAuthEmail
-            }
-
-            auth.signInWithEmailAndPassword(email, password)
-                .addOnCompleteListener { task ->
-                    if (task.isSuccessful) {
-                        val userId = auth.currentUser?.uid
-                        if (userId != null) {
-                            // Fetch the user document from Firestore
-                            db.collection("users").document(userId).get()
-                                .addOnSuccessListener { document ->
-                                    if (document != null && document.exists()) {
-                                        val isAdmin = document.getBoolean("isAdmin") ?: false
-                                        // Return success, the admin status, and no error
-                                        callback(true, isAdmin, null)
-                                    } else {
-                                        callback(false, false, "User data not found")
-                                    }
-                                }
-                                .addOnFailureListener { e ->
-                                    callback(false, false, e.message)
-                                }
-                        }
-                    } else {
-                        callback(false, false, task.exception?.message ?: "Login failed")
-                    }
-                }
+        val (email, error) = resolveAuthEmail(input)
+        if (email == null) {
+            callback(false, false, error)
+            return
         }
+
+        auth.signInWithEmailAndPassword(email, password)
+            .addOnCompleteListener { task ->
+                if (task.isSuccessful) {
+                    val userId = auth.currentUser?.uid
+                    if (userId != null) {
+                        db.collection("users").document(userId).get()
+                            .addOnSuccessListener { document ->
+                                if (document != null && document.exists()) {
+                                    val isAdmin = document.getBoolean("isAdmin") ?: false
+                                    callback(true, isAdmin, null)
+                                } else {
+                                    callback(false, false, "User data not found")
+                                }
+                            }
+                            .addOnFailureListener { e ->
+                                callback(false, false, e.message)
+                            }
+                    }
+                } else {
+                    callback(false, false, task.exception?.message ?: "Login failed")
+                }
+            }
     }
 }

--- a/app/src/main/java/com/example/soen345_winter2026/database/RegistrationDB.kt
+++ b/app/src/main/java/com/example/soen345_winter2026/database/RegistrationDB.kt
@@ -2,21 +2,65 @@ package com.example.soen345_winter2026.database
 
 import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.firestore.FirebaseFirestore
+import com.example.soen345_winter2026.utils.Validator
 
 class RegistrationDB(
     private val auth: FirebaseAuth = FirebaseAuth.getInstance(),
     private val db: FirebaseFirestore = FirebaseFirestore.getInstance()
 ) {
 
+    // change phone to fake email to pass firebase auth without needing phone
+    private fun phoneToEmail(phone: String): String {
+        return "$phone@phone.com"
+    }
+
+    // finds either the actual email linked to the acc
+    // or the phone-turned-email fake email linked
+    private fun lookupEmailByPhone(phone: String, callback: (String?, String?) -> Unit) {
+        db.collection("users")
+            .whereEqualTo("phone", phone)
+            .get()
+            .addOnSuccessListener { documents ->
+                if (!documents.isEmpty) {
+                    val email = documents.documents[0].getString("email")
+                    callback(email, null)
+                } else {
+                    callback(null, "No account found for this phone number")
+                }
+            }
+            .addOnFailureListener { e ->
+                callback(null, e.message)
+            }
+    }
+
+    private fun resolveAuthEmail(input: String, callback: (String?, String?) -> Unit) {
+        when {
+            Validator.isValidEmail(input) -> callback(input, null)
+            Validator.isValidPhoneNumber(input) -> lookupEmailByPhone(input, callback)
+            else -> callback(null, "Invalid email or phone number")
+        }
+    }
+
     fun signUp(
         email: String,
+        phone: String,
         password: String,
         fullName: String,
         isAdmin: Boolean,
         callback: (Boolean, String?) -> Unit
     ) {
 
-        auth.createUserWithEmailAndPassword(email, password)
+        val hasEmail = Validator.isValidEmail(email)
+        val hasPhone = Validator.isValidPhoneNumber(phone)
+
+        if (!hasEmail && !hasPhone) {
+            callback(false, "Please provide a valid email or phone number")
+            return
+        }
+
+        val authEmail = if (hasEmail) email else phoneToEmail(phone)
+
+        auth.createUserWithEmailAndPassword(authEmail, password)
             .addOnCompleteListener { task ->
 
                 if (task.isSuccessful) {
@@ -25,8 +69,9 @@ class RegistrationDB(
 
                     val user = hashMapOf(
                         "fullName" to fullName,
-                        "email" to email,
-                        "isAdmin" to isAdmin
+                        "email" to authEmail,
+                        "isAdmin" to isAdmin,
+                        "phone" to (if (hasPhone) phone else ""),
                     )
 
                     db.collection("users")
@@ -46,45 +91,64 @@ class RegistrationDB(
     }
 
     fun logIn(
-        email: String,
+        input: String,
         password: String,
         callback: (Boolean, String?) -> Unit
     ) {
 
-        auth.signInWithEmailAndPassword(email, password)
-            .addOnCompleteListener { task ->
-                if (task.isSuccessful) {
-                    callback(true, null)
-                } else {
-                    callback(false, task.exception?.message)
-                }
+        resolveAuthEmail(input) { email, error ->
+            if (email == null) {
+                callback(false, error)
+                return@resolveAuthEmail
             }
+
+
+            auth.signInWithEmailAndPassword(email, password)
+                .addOnCompleteListener { task ->
+                    if (task.isSuccessful) {
+                        callback(true, null)
+                    } else {
+                        callback(false, task.exception?.message)
+                    }
+                }
+        }
     }
 
-    fun adminLogIn(email: String, password: String, callback: (Boolean, Boolean, String?) -> Unit) {
-        auth.signInWithEmailAndPassword(email, password)
-            .addOnCompleteListener { task ->
-                if (task.isSuccessful) {
-                    val userId = auth.currentUser?.uid
-                    if (userId != null) {
-                        // Fetch the user document from Firestore
-                        db.collection("users").document(userId).get()
-                            .addOnSuccessListener { document ->
-                                if (document != null && document.exists()) {
-                                    val isAdmin = document.getBoolean("isAdmin") ?: false
-                                    // Return success, the admin status, and no error
-                                    callback(true, isAdmin, null)
-                                } else {
-                                    callback(false, false, "User data not found")
-                                }
-                            }
-                            .addOnFailureListener { e ->
-                                callback(false, false, e.message)
-                            }
-                    }
-                } else {
-                    callback(false, false, task.exception?.message ?: "Login failed")
-                }
+    fun adminLogIn(
+        input: String,
+        password: String,
+        callback: (Boolean, Boolean, String?) -> Unit) {
+
+        resolveAuthEmail(input) { email, error ->
+            if (email == null) {
+                callback(false, false, error)
+                return@resolveAuthEmail
             }
+
+            auth.signInWithEmailAndPassword(email, password)
+                .addOnCompleteListener { task ->
+                    if (task.isSuccessful) {
+                        val userId = auth.currentUser?.uid
+                        if (userId != null) {
+                            // Fetch the user document from Firestore
+                            db.collection("users").document(userId).get()
+                                .addOnSuccessListener { document ->
+                                    if (document != null && document.exists()) {
+                                        val isAdmin = document.getBoolean("isAdmin") ?: false
+                                        // Return success, the admin status, and no error
+                                        callback(true, isAdmin, null)
+                                    } else {
+                                        callback(false, false, "User data not found")
+                                    }
+                                }
+                                .addOnFailureListener { e ->
+                                    callback(false, false, e.message)
+                                }
+                        }
+                    } else {
+                        callback(false, false, task.exception?.message ?: "Login failed")
+                    }
+                }
+        }
     }
 }

--- a/app/src/main/res/layout/registration.xml
+++ b/app/src/main/res/layout/registration.xml
@@ -34,10 +34,10 @@
         android:textColor="#757575"/>
 
     <EditText
-        android:id="@+id/etEmail"
+        android:id="@+id/etEmailPhone"
         android:layout_width="match_parent"
         android:layout_height="50dp"
-        android:hint="Email"
+        android:hint="Email or phone (if phone, numbers only)"
         android:inputType="textEmailAddress"
         android:paddingLeft="15dp"
         android:layout_marginBottom="16dp"

--- a/app/src/main/res/layout/sign_up.xml
+++ b/app/src/main/res/layout/sign_up.xml
@@ -10,14 +10,14 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:orientation="vertical"
-        android:padding="24dp"
+        android:padding="22dp"
         android:gravity="center_vertical">
 
         <ImageView
             android:layout_width="80dp"
             android:layout_height="80dp"
             android:layout_gravity="center_horizontal"
-            android:layout_marginBottom="32dp"
+            android:layout_marginBottom="22dp"
             android:src="@mipmap/ic_launcher" />
 
         <TextView
@@ -27,7 +27,7 @@
             android:textSize="24sp"
             android:textStyle="bold"
             android:layout_gravity="center_horizontal"
-            android:layout_marginBottom="8dp"
+            android:layout_marginBottom="7dp"
             android:textColor="#212121"/>
 
         <TextView
@@ -35,7 +35,7 @@
             android:layout_height="wrap_content"
             android:text="Join us to get started"
             android:layout_gravity="center_horizontal"
-            android:layout_marginBottom="32dp"
+            android:layout_marginBottom="22dp"
             android:textColor="#757575"/>
 
         <EditText
@@ -52,8 +52,18 @@
             android:id="@+id/etEmail"
             android:layout_width="match_parent"
             android:layout_height="50dp"
-            android:hint="Email"
+            android:hint="Email (optional with phone)"
             android:inputType="textEmailAddress"
+            android:paddingLeft="15dp"
+            android:layout_marginBottom="16dp"
+            android:background="@android:drawable/edit_text" />
+
+        <EditText
+            android:id="@+id/etPhone"
+            android:layout_width="match_parent"
+            android:layout_height="50dp"
+            android:hint="Phone, numbers only (optional with email)"
+            android:inputType="phone"
             android:paddingLeft="15dp"
             android:layout_marginBottom="16dp"
             android:background="@android:drawable/edit_text" />
@@ -83,7 +93,7 @@
             android:layout_height="wrap_content"
             android:orientation="horizontal"
             android:gravity="center_vertical"
-            android:layout_marginBottom="24dp"
+            android:layout_marginBottom="22dp"
             android:paddingLeft="4dp"
             android:paddingRight="4dp">
 

--- a/app/src/test/java/com/example/soen345_winter2026/database/RegistrationDBTest.kt
+++ b/app/src/test/java/com/example/soen345_winter2026/database/RegistrationDBTest.kt
@@ -73,7 +73,7 @@ class RegistrationDBTest {
         every { mockTaskVoid.addOnSuccessListener(capture(firestoreSlot)) } returns mockTaskVoid
 
         var resultSuccess = false
-        registrationDB.signUp(email, pass, name, false) { success, _ ->
+        registrationDB.signUp(email, "", pass, name, false) { success, _ ->
             resultSuccess = success
         }
 
@@ -94,7 +94,7 @@ class RegistrationDBTest {
         val authSlot = slot<OnCompleteListener<AuthResult>>()
         every { mockTaskAuth.addOnCompleteListener(capture(authSlot)) } returns mockTaskAuth
 
-        registrationDB.signUp("a@b.com", "123", "Name", false) { success, msg ->
+        registrationDB.signUp("a@b.com", "", "123", "Name", false) { success, msg ->
             assertFalse(success)
             assertEquals(errorMsg, msg)
         }
@@ -168,7 +168,7 @@ class RegistrationDBTest {
         var resultSuccess: Boolean? = null
         var resultMsg: String? = null
 
-        registrationDB.signUp(email, pass, name, true) { success, msg ->
+        registrationDB.signUp(email, "", pass, name, true) { success, msg ->
             resultSuccess = success
             resultMsg = msg
         }

--- a/app/src/test/java/com/example/soen345_winter2026/database/RegistrationDBTest.kt
+++ b/app/src/test/java/com/example/soen345_winter2026/database/RegistrationDBTest.kt
@@ -300,4 +300,142 @@ class RegistrationDBTest {
         authSlot.captured.onComplete(mockTaskAuth)
         failureSlot.captured.onFailure(Exception(errorMsg))
     }
+
+    @Test
+    fun `signUp - phone only auth and firestore succeed`() {
+        val phone = "15143334444"
+        val fakeEmail = "15143334444@phone.com"
+        val pass = "password123"
+        val name = "John Doe"
+        val uid = "user_123"
+
+        // 1. Mock Auth Creation
+        every { mockAuth.createUserWithEmailAndPassword(fakeEmail, pass) } returns mockTaskAuth
+        every { mockTaskAuth.isSuccessful } returns true
+        every { mockAuth.currentUser } returns mockUser
+        every { mockUser.uid } returns uid
+
+        // 2. Mock Firestore Storage
+        val mockDocRef = mockk<DocumentReference>(relaxed = true)
+        val mockColRef = mockk<CollectionReference>(relaxed = true)
+        every { mockDb.collection("users") } returns mockColRef
+        every { mockColRef.document(uid) } returns mockDocRef
+        every { mockDocRef.set(any()) } returns mockTaskVoid
+
+        // Capture the Auth Listener
+        val authSlot = slot<OnCompleteListener<AuthResult>>()
+        every { mockTaskAuth.addOnCompleteListener(capture(authSlot)) } returns mockTaskAuth
+
+        // Capture the Firestore Success Listener
+        val firestoreSlot = slot<OnSuccessListener<Void>>()
+        every { mockTaskVoid.addOnSuccessListener(capture(firestoreSlot)) } returns mockTaskVoid
+
+        var resultSuccess = false
+        registrationDB.signUp("", phone, pass, name, false) { success, _ ->
+            resultSuccess = success
+        }
+
+        // Trigger callbacks manually
+        authSlot.captured.onComplete(mockTaskAuth)
+        firestoreSlot.captured.onSuccess(null)
+
+        assertTrue(resultSuccess)
+    }
+
+    @Test
+    fun `signUp - fail when both email and phone missing`() {
+        val errorMsg = "Please provide a valid email or phone number"
+
+        registrationDB.signUp("", "", "12345678", "Name", false) { success, msg ->
+            assertFalse(success)
+            assertEquals(errorMsg, msg)
+        }
+    }
+
+    @Test
+    fun `logIn - fail when cannot resolve input to phone or email`() {
+        val errorMsg = "Invalid email or phone number"
+
+        registrationDB.logIn("whatever", "12345678") { success, msg ->
+            assertFalse(success)
+            assertEquals(errorMsg, msg)
+        }
+    }
+
+    @Test
+    fun `logIn - success with valid phone input`() {
+        val phone = "15143334444"
+        val fakeEmail = "15143334444@phone.com"
+
+        every { mockAuth.signInWithEmailAndPassword(fakeEmail, any()) } returns mockTaskAuth
+        every { mockTaskAuth.isSuccessful } returns true
+
+        val slot = slot<OnCompleteListener<AuthResult>>()
+        every { mockTaskAuth.addOnCompleteListener(capture(slot)) } returns mockTaskAuth
+
+        registrationDB.logIn(phone, "password123") { success, _ ->
+            assertTrue(success)
+        }
+
+        slot.captured.onComplete(mockTaskAuth)
+    }
+
+    @Test
+    fun `logIn - success with valid phone input for admin`() {
+        val phone = "15143334444"
+        val fakeEmail = "15143334444@phone.com"
+        val uid = "admin_123"
+        val mockDocSnapshot = mockk<com.google.firebase.firestore.DocumentSnapshot>(relaxed = true)
+        val mockTaskGet = mockk<Task<com.google.firebase.firestore.DocumentSnapshot>>(relaxed = true)
+
+        // 1. Mock Auth Success
+        every { mockAuth.signInWithEmailAndPassword(fakeEmail, any()) } returns mockTaskAuth
+        every { mockTaskAuth.isSuccessful } returns true
+        every { mockAuth.currentUser } returns mockUser
+        every { mockUser.uid } returns uid
+
+        // 2. Mock Firestore Success
+        every { mockDb.collection("users").document(uid).get() } returns mockTaskGet
+        every { mockDocSnapshot.exists() } returns true
+        every { mockDocSnapshot.getBoolean("isAdmin") } returns true
+
+        val authSlot = slot<OnCompleteListener<AuthResult>>()
+        val firestoreSlot = slot<OnSuccessListener<com.google.firebase.firestore.DocumentSnapshot>>()
+
+        every { mockTaskAuth.addOnCompleteListener(capture(authSlot)) } returns mockTaskAuth
+        every { mockTaskGet.addOnSuccessListener(capture(firestoreSlot)) } returns mockTaskGet
+
+        var successRes = false
+        var adminRes = false
+        registrationDB.adminLogIn(phone, "password") { success, isAdmin, _ ->
+            successRes = success
+            adminRes = isAdmin
+        }
+
+        // Trigger chain
+        authSlot.captured.onComplete(mockTaskAuth)
+        firestoreSlot.captured.onSuccess(mockDocSnapshot)
+
+        assertTrue(successRes)
+        assertTrue(adminRes)
+    }
+    
+    @Test
+    fun `logIn - phone login fails when account has email`() {
+        val phone = "15143334444"
+        val fakeEmail = "15143334444@phone.com"
+
+        every { mockAuth.signInWithEmailAndPassword(fakeEmail, any()) } returns mockTaskAuth
+        every { mockTaskAuth.isSuccessful } returns false
+
+        val slot = slot<OnCompleteListener<AuthResult>>()
+        every { mockTaskAuth.addOnCompleteListener(capture(slot)) } returns mockTaskAuth
+
+        registrationDB.logIn(phone, "password123") { success, _ ->
+            assertFalse(success)
+        }
+
+        slot.captured.onComplete(mockTaskAuth)
+    }
+
 }


### PR DESCRIPTION
Added field in sign up for phone and phone number may be used to login*

(former behaviour) 
- email is needed to create account for login

(current behaviour)
- choice of phone or email in account creation, both can be added
- phone login is available*
- signing up with only phone transforms the phone number string into a fake email (number@phone.com) to pass the auth

(issues)
- if user signs up with phone and email, only email can be used to login as there is no string for fake phone number conversion
- this trade off was decided to go against the loosening of firebase rules (allowing users to check the user database before logging in represents a security risk)